### PR TITLE
Aligns words only if the first word of each line matches.

### DIFF
--- a/syntax/format.go
+++ b/syntax/format.go
@@ -105,7 +105,7 @@ func formatTupleGroup(indent int, group []*tupleNode) (
 		lists = append(lists, list)
 	}
 
-	alignWords(wordss)
+	alignWordsGroupedByFirstWord(wordss)
 
 	var line []byte
 	addLine := func() {
@@ -230,6 +230,33 @@ func stringifyTuple(tuple *tupleNode) (words []string, list *listNode,
 		words = append(words, word)
 	}
 	return words, nil, nil
+}
+
+func alignWordsGroupedByFirstWord(lines [][]string) {
+	groups := [][][]string{}
+	prev := ""
+	group := [][]string{}
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		if prev == "" {
+			prev = line[0]
+			group = append(group, line)
+		} else if line[0] == prev {
+			group = append(group, line)
+		} else {
+			prev = line[0]
+			groups = append(groups, group)
+			group = [][]string{line}
+		}
+	}
+	if len(group) > 0 {
+		groups = append(groups, group)
+	}
+	for _, group := range groups {
+		alignWords(group)
+	}
 }
 
 func alignWords(wordss [][]string) {


### PR DESCRIPTION
For example, the old formatter would have done this:

read first (
	select  conversation
	where   conversation.user_id    =            ?
	where   conversation.example_id =            ?
	orderby desc                    conversation
)

But with this change you get this instead:

read first (
	select conversation
	where conversation.user_id    = ?
	where conversation.example_id = ?
	orderby desc conversation.dm_timestamp
)